### PR TITLE
Add parameter to configure external image pull secret for registry deployment

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -36,6 +36,7 @@ parameters:
         save ""
 
     registry:
+      pullSecretName: ~
       resources:
         requests:
           memory: '200Mi'

--- a/component/registry.jsonnet
+++ b/component/registry.jsonnet
@@ -71,6 +71,11 @@ local registryDeployment = kube.Deployment('registry') {
             resources: params.registry.resources,
           },
         },
+        [if params.registry.pullSecretName != null then 'imagePullSecrets']: [
+          {
+            name: params.registry.pullSecretName,
+          },
+        ],
         volumes_: {
           config: {
             secret: {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -53,6 +53,19 @@ default:: `1G`
 
 Max amount of memory Redis may consume.
 
+== `registry.pullSecretName`
+
+[horizontal]
+type:: string
+default:: `~`
+
+The name of an image pull secret to use, if not null.
+
+[NOTE]
+====
+We currently don't support generating an image pull secret from the component, as we don't have a way to generate the required contents from Vault secrets.
+Instead, we provide this parameter so that users can tell the component to configure the deployment with an externally-managed image pull secret.
+====
 
 == `registry.config.storage.s3.bucket`, `registry.config.storage.s3.regionendpoint`
 


### PR DESCRIPTION
We currently don't support generating an image pull secret from the component, as we don't have a way to generate the required contents from Vault secrets.
Instead, we provide a new parameter so that users can tell the component to configure the deployment with an externally-managed image pull secret.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
