### PR TITLE
Add component parameter `imagePullSecretName`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,6 +16,7 @@ parameters:
     replicas: 2
 
     http_secret: '?{vaultkv:${cluster:tenant}/${cluster:name}/registry-cache/http_secret}'
+    imagePullSecretName: ~
 
     redis:
       enabled: true
@@ -36,7 +37,6 @@ parameters:
         save ""
 
     registry:
-      pullSecretName: ~
       resources:
         requests:
           memory: '200Mi'

--- a/component/redis.jsonnet
+++ b/component/redis.jsonnet
@@ -78,6 +78,11 @@ local redisDeployment = kube.Deployment('redis') {
             },
           },
         },
+        [if params.imagePullSecretName != null then 'imagePullSecrets']: [
+          {
+            name: params.imagePullSecretName,
+          },
+        ],
         volumes: [ {
           configMap: {
             defaultMode: 420,

--- a/component/registry.jsonnet
+++ b/component/registry.jsonnet
@@ -11,6 +11,16 @@ local commonLabels = {
   'app.kubernetes.io/part-of': 'syn',
 };
 
+local pullSecret =
+  if std.objectHas(params.registry, 'pullSecretName') then
+    std.trace(
+      'Parameter `registry.pullSecretName` is deprecated,'
+      + ' please use parameter `imagePullSecretName` instead',
+      params.registry.pullSecretName
+    )
+  else
+    params.imagePullSecretName;
+
 // see: https://docs.docker.com/registry/configuration/
 local config = params.registry.config {
   version: '0.1',
@@ -71,9 +81,9 @@ local registryDeployment = kube.Deployment('registry') {
             resources: params.registry.resources,
           },
         },
-        [if params.registry.pullSecretName != null then 'imagePullSecrets']: [
+        [if pullSecret != null then 'imagePullSecrets']: [
           {
-            name: params.registry.pullSecretName,
+            name: pullSecret,
           },
         ],
         volumes_: {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -37,6 +37,22 @@ possible values:: `ingress` or `route`
 
 Whether to use an `Ingress` or `Route` object to expose the registry.
 
+== `imagePullSecretName`
+
+[horizontal]
+type:: string
+default:: `~`
+
+The name of an image pull secret to use, if not null.
+The secret is configured for both the Registry and the Redis deployments.
+
+[NOTE]
+====
+We currently don't support generating an image pull secret from the component, as we don't have a way to generate the required contents from Vault secrets.
+Instead, we provide this parameter so that users can tell the component to configure the deployment with an externally-managed image pull secret.
+====
+
+
 == `redis.enabled`
 
 [horizontal]
@@ -52,20 +68,6 @@ type:: bytes
 default:: `1G`
 
 Max amount of memory Redis may consume.
-
-== `registry.pullSecretName`
-
-[horizontal]
-type:: string
-default:: `~`
-
-The name of an image pull secret to use, if not null.
-
-[NOTE]
-====
-We currently don't support generating an image pull secret from the component, as we don't have a way to generate the required contents from Vault secrets.
-Instead, we provide this parameter so that users can tell the component to configure the deployment with an externally-managed image pull secret.
-====
 
 == `registry.config.storage.s3.bucket`, `registry.config.storage.s3.regionendpoint`
 


### PR DESCRIPTION
Instead of having separate configs for the registry and Redis image pull secrets, we change the component to have a single parameter `imagePullSecretName` which defines the name of an externally managed Secret resource to use for both deployments.

The change is backwards-compatible and will use the value of parameter `registry.pullSecretName` for the Registry deployment, if that parameter exists in the hierarchy.

Follow-up to #10 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
