### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "ignorePaths": [
     ".github/**"


### PR DESCRIPTION
## Summary
- migrate the Renovate preset from `config:base` to `config:recommended`
- keep the existing ignore paths, labels, automerge, and post-upgrade task settings unchanged

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`

This addresses the Renovate Dependency Dashboard config migration notice in #7.